### PR TITLE
Fixed the malformed JSON on the consumer

### DIFF
--- a/restmq/collectd.py
+++ b/restmq/collectd.py
@@ -55,7 +55,7 @@ class CollectdRestQueueHandler(web.RestQueueHandler):
         try:
             result = yield self.settings.oper.queue_add(queue, value)
         except Exception, e:
-            log.msg("ERROR: oper.queue_add('%s', '%s') failed: %s" % (queue, val, e))
+            log.msg("ERROR: oper.queue_add('%s', '%s') failed: %s" % (queue, value, e))
             raise cyclone.web.HTTPError(503)
 
         if result:


### PR DESCRIPTION
The consumer was receiveing mutiple objects from the queue and tried to decode them all the same time.

Dont know if this is the correct behaviour for the comet consumer
