### PR TITLE
Vagrantfile added in order to simplify installation and configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ Install
 $ python setup.py install
 run with bash start_scripts/restmq_server or taylor your own script. Note that currently restmq is presented as a twisted plugin. 
 
+Alternatively you can utilize [Vagrant](https://www.vagrantup.com/) and our [Vagrantfile](Vagrantfile) which will handle installation and configuration of redis and RestMQ.
+
 Queue Policy
 ============
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+VAGRANTFILE_API_VERSION = "2"
+
+
+$script = <<SCRIPT
+
+apt-get update
+apt-get install git curl python-pip redis-server libffi-dev python-dev -y libssl-dev
+
+git clone https://github.com/gleicon/restmq.git
+cd restmq
+pip install -e .
+
+cd start_scripts
+touch acl.conf
+bash restmq_server --acl=acl.conf --listen=0.0.0.0 &
+
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise32"
+  config.vm.provision "shell", inline: $script
+  config.vm.network "forwarded_port", guest: 8888, host: 8888
+end


### PR DESCRIPTION
It could be quite challenging to build and run RestMQ on some environments. As a workaround here Vagrantfile that automates installation and building of RestMQ

Partly fixes issue #13 
